### PR TITLE
Add example implementation: create mousewheel events when turning the knob

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ if len(devices) > 0:
     powermate.close()
 ```
 
+A simple example implementation is included:  
+Create mousewheel events when turning the knob (coarse when button pressed, fine when not pressed)
+
 ## API
 TBC
 

--- a/griffin_powermate/griffin_powermate.py
+++ b/griffin_powermate/griffin_powermate.py
@@ -67,11 +67,32 @@ if __name__ == '__main__':
     from time import sleep
     from msvcrt import kbhit
 
+    # example implementation: create mousewheel events when turning the knob (coarse when button pressed, fine when not pressed)
+    import win32api # pip install pywin32
+    from win32con import *
+    import pyautogui # pip install pyautogui
+
+    MOUSEWHEEL_STEPSIZE_COARSE = 50
+    MOUSEWHEEL_STEPSIZE_FINE = 5
+    
     def move_listener(direction, button):
         print("Moved: {0} - {1}"
               .format('LEFT' if direction == GriffinPowermate.MOVE_LEFT
                       else 'RIGHT', button))
 
+        # here we create mousewheel events
+        mouse_pos = pyautogui.position()
+        if button == 1: # coarse mousewheel
+            if direction == GriffinPowermate.MOVE_RIGHT:
+                win32api.mouse_event(MOUSEEVENTF_WHEEL, mouse_pos[0], mouse_pos[1], MOUSEWHEEL_STEPSIZE_COARSE, 0)
+            else:
+                win32api.mouse_event(MOUSEEVENTF_WHEEL, mouse_pos[0], mouse_pos[1], -MOUSEWHEEL_STEPSIZE_COARSE, 0)
+        else: # if button == 0, fine mousewheel
+            if direction == GriffinPowermate.MOVE_RIGHT:
+                win32api.mouse_event(MOUSEEVENTF_WHEEL, mouse_pos[0], mouse_pos[1], MOUSEWHEEL_STEPSIZE_FINE, 0)
+            else:
+                win32api.mouse_event(MOUSEEVENTF_WHEEL, mouse_pos[0], mouse_pos[1], -MOUSEWHEEL_STEPSIZE_FINE, 0)
+        
     def raw_listener(data):
         print "Moved: {0}".format(data)
 


### PR DESCRIPTION
Hi,

first of all, thanks for this. :)
I recently aquired a Powermate and was quite disappointed to find out it isn't working/supported anymore in current Windows versions (should have done some research before).
Happy I finally got it working with the help of your library.

Anyway, to my PR:
Having never written a single line of Python before (though I programmed in other languages), I found it not easy at first to make your library actually 'do something'.
So I thought providing an example implementation could make it more easy for other noobs to get started.

PS: If you don't want to merge, simply close it, I won't be sad. :)
 